### PR TITLE
Update device_generation into python3 module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ routing
 constraint_generation
 thirdparty
 *.pyc
+
+*bound
+*con
+*gds
+*gr
+*gr.spec
+*ioPin
+*iopin
+*pin
+*sym
+*symnet

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,7 @@
 [submodule "anaroute"]
 	path = anaroute
 	url = git@github.com:baloneymath/anaroute.git
+
 [submodule "device_generation"]
 	path = device_generation
-	url = https://github.com/krzhu/device_generation.git
+	url = https://github.com/jayl940712/device_generation.git

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install device_generation/
 pip install ConstGen/
 pip install IdeaPlaceEX/
 pip install anaroute/

--- a/examples/adc1/run.sh
+++ b/examples/adc1/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py adc1.json

--- a/examples/adc2/run.sh
+++ b/examples/adc2/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py CTDSM_CORE_NEW.json

--- a/examples/comp/run.sh
+++ b/examples/comp/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py comp.json

--- a/examples/ota1/run.sh
+++ b/examples/ota1/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py ota1.json

--- a/examples/ota2/run.sh
+++ b/examples/ota2/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py ota2.json

--- a/examples/ota3/run.sh
+++ b/examples/ota3/run.sh
@@ -1,1 +1,2 @@
+mkdir gds
 python ../../flow/python/Magical.py Telescopic_Three_stage_flow.json

--- a/flow/python/Device_generator.py
+++ b/flow/python/Device_generator.py
@@ -5,7 +5,6 @@
 #
 
 import sys, os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 from device_generation.Mosfet import Mosfet
 from device_generation.Capacitor import Capacitor
 from device_generation.Resistor import Resistor

--- a/flow/python/Placer.py
+++ b/flow/python/Placer.py
@@ -3,7 +3,6 @@ import IdeaPlaceExPy
 import anaroutePy
 import sys
 import os.path
-sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 import device_generation.basic as basic
 import gdspy
 import device_generation.glovar as glovar

--- a/flow/python/PnR.py
+++ b/flow/python/PnR.py
@@ -9,7 +9,6 @@ import IdeaPlaceExPy
 import anaroutePy
 import sys
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 import Router
 import Placer
 import gdspy

--- a/flow/python/Router.py
+++ b/flow/python/Router.py
@@ -9,7 +9,6 @@ import sys
 import MagicalDB
 import magicalFlow
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 import device_generation.basic as basic
 
 class Router(object):


### PR DESCRIPTION
The device generation has been updated into a python3 module.
Examples have been tested. adc2 top routing failed. All other test cases passed.
I have also removed the relative path imports for device_generation in the /flow/*py scripts.
